### PR TITLE
Set TravisCI to run on JDK 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+    - oraclejdk8


### PR DESCRIPTION
This PR sets the travis CI up to run as a java project, using the JDK 8.
